### PR TITLE
Update package's dependencies to Angular 6, 7 or 8

### DIFF
--- a/projects/ngx-spinner/package.json
+++ b/projects/ngx-spinner/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/Napster2210/ngx-spinner.git/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^7.2.0",
-    "@angular/core": "^7.2.0"
+    "@angular/common": "^6.0.0 || ^7.0.0 || ^8.0.0",
+    "@angular/core": "^6.0.0 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
Change package's dependencies to support all three versions of Angular.
This will remove the following npm (or yarn) warning when not using Angular ^7.2.0 : 
```bash
npm WARN ngx-spinner@8.0.1 requires a peer of @angular/common@^7.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN ngx-spinner@8.0.1 requires a peer of @angular/core@^7.2.0 but none is installed. You must install peer dependencies yourself.
```