### PR TITLE
hide all spinners

### DIFF
--- a/projects/ngx-spinner/src/lib/ngx-spinner.enum.ts
+++ b/projects/ngx-spinner/src/lib/ngx-spinner.enum.ts
@@ -61,6 +61,7 @@ export const DEFAULTS = {
 };
 
 export const PRIMARY_SPINNER = 'primary';
+export const ALL_SPINNERS = 'all';
 
 export type Size = 'default' | 'small' | 'medium' | 'large';
 

--- a/projects/ngx-spinner/src/lib/ngx-spinner.service.ts
+++ b/projects/ngx-spinner/src/lib/ngx-spinner.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@angular/core';
-import { Observable, ReplaySubject } from 'rxjs';
-import { filter } from 'rxjs/operators';
-import { NgxSpinner, PRIMARY_SPINNER, Spinner } from './ngx-spinner.enum';
+import {Injectable} from '@angular/core';
+import {Observable, ReplaySubject} from 'rxjs';
+import {filter} from 'rxjs/operators';
+import {ALL_SPINNERS, NgxSpinner, PRIMARY_SPINNER, Spinner} from './ngx-spinner.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -13,18 +13,28 @@ export class NgxSpinnerService {
    * @memberof NgxSpinnerService
    */
   private spinnerObservable = new ReplaySubject<NgxSpinner>(1);
+
+  private spinners: string[] = [];
+
   /**
    * Creates an instance of NgxSpinnerService.
    * @memberof NgxSpinnerService
    */
-  constructor() { }
+  constructor() {
+  }
+
   /**
-  * Get subscription of desired spinner
-  * @memberof NgxSpinnerService
-  **/
+   * Get subscription of desired spinner
+   * @memberof NgxSpinnerService
+   **/
   getSpinner(name: string): Observable<NgxSpinner> {
+    if (!this.spinners.includes(name)) {
+      this.spinners.push(name);
+    }
+
     return this.spinnerObservable.asObservable().pipe(filter((x: NgxSpinner) => x && x.name === name));
   }
+
   /**
    * To show spinner
    *
@@ -34,23 +44,30 @@ export class NgxSpinnerService {
     const showPromise = new Promise((resolve, reject) => {
       if (spinner && Object.keys(spinner).length) {
         spinner['name'] = name;
-        this.spinnerObservable.next(new NgxSpinner({ ...spinner, show: true }));
+        this.spinnerObservable.next(new NgxSpinner({...spinner, show: true}));
         resolve(true);
       } else {
-        this.spinnerObservable.next(new NgxSpinner({ name, show: true }));
+        this.spinnerObservable.next(new NgxSpinner({name, show: true}));
         resolve(true);
       }
     });
     return showPromise;
   }
+
   /**
-  * To hide spinner
-  *
-  * @memberof NgxSpinnerService
-  */
-  hide(name: string = PRIMARY_SPINNER) {
+   * To hide spinner
+   *
+   * @memberof NgxSpinnerService
+   */
+  hide(name: string = ALL_SPINNERS) {
     const hidePromise = new Promise((resolve, reject) => {
-      this.spinnerObservable.next(new NgxSpinner({ name, show: false }));
+      if (name === ALL_SPINNERS) {
+        this.spinners.forEach((spinnerName) => {
+          this.spinnerObservable.next(new NgxSpinner({name: spinnerName, show: false}));
+        });
+      } else {
+        this.spinnerObservable.next(new NgxSpinner({name, show: false}));
+      }
       resolve(true);
     });
     return hidePromise;

--- a/projects/ngx-tester/src/app/app.component.ts
+++ b/projects/ngx-tester/src/app/app.component.ts
@@ -120,7 +120,8 @@ export class AppComponent {
   showSpinner(name: string) {
     this.spinner.show(name);
     setTimeout(() => {
-      this.spinner.hide(name);
+      this.spinner.hide();
     }, 3000);
   }
 }
+


### PR DESCRIPTION
Implement the ability to hide all spinners.
Hiding all spinners will now happen if no `name` argument is supplied to the `.hide()` method