### PR TITLE
fix: peerDependencies require min angular >=15

### DIFF
--- a/projects/ngx-spinner/package.json
+++ b/projects/ngx-spinner/package.json
@@ -64,8 +64,8 @@
     "url": "https://github.com/Napster2210/ngx-spinner.git/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^15.0.0",
-    "@angular/core": "^15.0.0"
+    "@angular/common": ">=15.0.0",
+    "@angular/core": ">=15.0.0"
   },
   "schematics": "./schematics/collection.json",
   "ng-add": {


### PR DESCRIPTION
Currently this package can not be used in an Angular 16 projects because the peerDependencies are not updated.
This PR should provide a fix.

> npm ERR! Found: @angular/common@16.0.2
> npm ERR! node_modules/@angular/common
> npm ERR!   @angular/common@"^16.0.2" from the root project
> npm ERR!
> npm ERR! Could not resolve dependency:
> npm ERR! peer @angular/common@"^15.0.0" from ngx-spinner@16.0.0
> npm ERR! node_modules/ngx-spinner
> npm ERR!   ngx-spinner@"*" from the root project
> npm ERR!
> npm ERR! Fix the upstream dependency conflict, or retry
> npm ERR! this command with --force or --legacy-peer-deps
> npm ERR! to accept an incorrect (and potentially broken) dependency resolution.